### PR TITLE
修复 `AT+CFUN?` 响应解析错误的问题

### DIFF
--- a/code/code.ino
+++ b/code/code.ino
@@ -759,7 +759,7 @@ void handleFlightMode() {
     if (resp.indexOf("+CFUN:") >= 0) {
       success = true;
       int idx = resp.indexOf("+CFUN:");
-      int mode = resp.substring(idx + 6, idx + 7).toInt();
+      int mode = resp.substring(idx + 6).toInt();
       
       String modeStr;
       String statusIcon;
@@ -792,7 +792,7 @@ void handleFlightMode() {
     
     if (resp.indexOf("+CFUN:") >= 0) {
       int idx = resp.indexOf("+CFUN:");
-      int currentMode = resp.substring(idx + 6, idx + 7).toInt();
+      int currentMode = resp.substring(idx + 6).toInt();
       
       // 切换模式：1(正常) <-> 4(飞行模式)
       int newMode = (currentMode == 1) ? 4 : 1;


### PR DESCRIPTION
 `AT+CFUN?` 响应举例：

```
//     +CFUN: 1
//           ^
// idx 0     67
```

解析时用 `resp.substring(idx + 6, idx + 7)`，substring 的范围是 `[start, end)`，实际上总是在解析空格。

解析错误影响模块状态查询和飞行模式切换。

改为 `resp.substring(idx + 7, idx + 8)` 或者  `resp.substring(idx + 6)` 即可，这个 patch 里用  `resp.substring(idx + 6)`。