### PR TITLE
Add Web-based WiFi configuration and AP mode

### DIFF
--- a/code/wifi_config.h
+++ b/code/wifi_config.h
@@ -1,3 +1,3 @@
 //WIFI - 仍使用宏定义，因为需要先联网才能配置其他参数
-#define WIFI_SSID "你家wifi"
-#define WIFI_PASS "你家wifi密码"
+#define WIFI_SSID "XXX"
+#define WIFI_PASS "12345678"


### PR DESCRIPTION
### 🚀 新功能：网页配网与 AP 模式自动回退

本 PR 引入了网页端 WiFi 配置功能和自动 AP 模式回退机制，使网络配置更加便捷。

#### ✨ 主要变更
1. **网页端 WiFi 配置**：
   - 在 Web 界面新增了 WiFi SSID 和密码输入框，支持动态修改。
   - 配置信息保存于 NVS (`wifiSSID`, `wifiPass`)，掉电不丢失。

2. **智能 AP 回退机制**：
   - **运行逻辑**：设备开机后尝试连接 WiFi。如果 **30秒内** 未能成功连接，设备将自动切换到 AP（热点）模式。
   - **热点名称**：`SMS-Forwarder-AP`
   - **配置地址**：`http://192.168.4.1`

3. **UI 改进**：
   - 修复了 HTML 页面中的图标乱码问题。

#### 📖 使用说明
1. 设备开机。
2. 如果 **30秒内** 无法连接 WiFi，设备会开启名为 **`SMS-Forwarder-AP`** 的热点。
3. 连接该热点，并在浏览器访问 **`http://192.168.4.1`**。
4. 在页面顶部输入新的 WiFi 账号密码并保存。
5. 设备将自动重启并连接新 WiFi。