### PR TITLE
修复飞书签名生成

### DIFF
--- a/code/push.cpp
+++ b/code/push.cpp
@@ -263,14 +263,13 @@ void sendToChannel(const PushChannel& channel, const char* sender, const char* m
       if (channel.key1.length() > 0) {
         // 飞书使用秒级时间戳
         int64_t ts = time(nullptr);
-        // 飞书签名: base64(hmac-sha256(timestamp + "\n" + secret, secret))
+        // 飞书签名: base64(HMAC-SHA256(key=timestamp + "\n" + secret, msg=""))
         String stringToSign = String(ts) + "\n" + channel.key1;
         uint8_t hmacResult[32];
         mbedtls_md_context_t ctx;
         mbedtls_md_init(&ctx);
         mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
-        mbedtls_md_hmac_starts(&ctx, (const unsigned char*)channel.key1.c_str(), channel.key1.length());
-        mbedtls_md_hmac_update(&ctx, (const unsigned char*)stringToSign.c_str(), stringToSign.length());
+        mbedtls_md_hmac_starts(&ctx, (const unsigned char*)stringToSign.c_str(), stringToSign.length());
         mbedtls_md_hmac_finish(&ctx, hmacResult);
         mbedtls_md_free(&ctx);
         String sign = base64::encode(hmacResult, 32);


### PR DESCRIPTION
在[飞书机器人文档](https://open.feishu.cn/document/client-docs/bot-v3/add-custom-bot?lang=zh-CN#3c6592d6)中，签名生成的方式为将`timestamp + "\n" + 密钥`当做签名字符串，使用 HmacSHA256 算法计算空字符串的签名结果。

当前的代码使用密钥作为签名字符串，计算`timestamp + "\n" + 密钥`字符串的签名结果，生成了错误的sign。